### PR TITLE
make SLF4J dependency explicit

### DIFF
--- a/maven-jxr/pom.xml
+++ b/maven-jxr/pom.xml
@@ -92,7 +92,11 @@ under the License.
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.30</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.velocity</groupId>
       <artifactId>velocity-engine-core</artifactId>


### PR DESCRIPTION
Alternative would be to remove the SLF4J loggers and debug log statements completely. 