### PR TITLE
[JXR-170] NullPointerException while parsing Java 15 multi-line String source

### DIFF
--- a/maven-jxr-plugin/src/it/JXR-143_nofork/pom.xml
+++ b/maven-jxr-plugin/src/it/JXR-143_nofork/pom.xml
@@ -44,6 +44,7 @@ under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <goals>

--- a/maven-jxr/src/main/java/org/apache/maven/jxr/pacman/ClassType.java
+++ b/maven-jxr/src/main/java/org/apache/maven/jxr/pacman/ClassType.java
@@ -41,7 +41,7 @@ public class ClassType
     @Deprecated
     public ClassType( String name )
     {
-        this.setName( name );
+        this( name, null );
     }
 
     /**
@@ -52,7 +52,8 @@ public class ClassType
      */
     public ClassType( String name, String filename )
     {
-        this.setName( name );
+        super( name );
+
         this.setFilename( filename );
     }
 

--- a/maven-jxr/src/main/java/org/apache/maven/jxr/pacman/ImportType.java
+++ b/maven-jxr/src/main/java/org/apache/maven/jxr/pacman/ImportType.java
@@ -39,7 +39,7 @@ public class ImportType
      */
     public ImportType( String name )
     {
-        this.setName( name );
+        super( name );
 
         //compute member variables
 

--- a/maven-jxr/src/main/java/org/apache/maven/jxr/pacman/PackageType.java
+++ b/maven-jxr/src/main/java/org/apache/maven/jxr/pacman/PackageType.java
@@ -39,7 +39,7 @@ public class PackageType
      */
     public PackageType( String name )
     {
-        this.setName( name );
+        super( name );
     }
 
     /**
@@ -47,8 +47,8 @@ public class PackageType
      */
     public PackageType()
     {
+        super( "" );
     }
-
 
     /**
      * Get all the known classes

--- a/maven-jxr/src/test/java/org/apache/maven/jxr/pacman/JavaFileImplTest.java
+++ b/maven-jxr/src/test/java/org/apache/maven/jxr/pacman/JavaFileImplTest.java
@@ -46,4 +46,14 @@ public class JavaFileImplTest {
         assertEquals( "NotNested", classTypes.next().getName() );
     }
 
+    @Test
+    public void testJXR_170_multiLineString() throws IOException
+    {
+        JavaFileImpl javaFile = new JavaFileImpl( Paths.get(
+                "src/test/resources/jxr170/org/apache/maven/jxr/pacman/ClassWithMultiLineString.java" ),
+                "UTF-8" );
+        assertEquals( 1, javaFile.getClassTypes().size() );
+        assertEquals( "ClassWithMultiLineString", javaFile.getClassTypes().get(0).getName() );
+        assertEquals( "[ImportType[name=java.lang.*]]", javaFile.getImportTypes().toString() );
+    }
 }

--- a/maven-jxr/src/test/resources/jxr170/org/apache/maven/jxr/pacman/ClassWithMultiLineString.java
+++ b/maven-jxr/src/test/resources/jxr170/org/apache/maven/jxr/pacman/ClassWithMultiLineString.java
@@ -1,4 +1,4 @@
-package org.apache.maven.jxr.pacman;
+package org.apache.maven.jxr;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,42 +19,22 @@ package org.apache.maven.jxr.pacman;
  * under the License.
  */
 
-import java.util.Objects;
-
 /**
- * put your documentation comment here
+ * Test Java source of the test for JXR-170.
  *
- * @author jvanzyl
+ * @author Markus Spann
  */
-public abstract class BaseType
-{
-    private final String name;
+public class ClassWithMultiLineString {
 
-    /**
-     * Construct type and set its name.
-     *
-     * @param name type name
-     */
-    public BaseType( String name )
-    {
-        this.name = Objects.requireNonNull( name );
+    private final String str;
+
+    public ClassWithMultiLineString(String _str) {
+        str = _str;
     }
 
-    /**
-     * Get the name for this type
-     *
-     * @return The name value
-     */
-    public String getName()
-    {
-        return this.name;
+    public static void main(String[] args) {
+        new ClassWithMultiLineString("""
+                import java.util.List;
+                """);
     }
-
-    @Override
-    public String toString()
-    {
-        return getClass().getSimpleName() + "[name=" + name + "]";
-    }
-
 }
-


### PR DESCRIPTION
This PR offers a fix for bug [JXR-170]. Summary of changes:

- Add support for parsing sources with Java 15 multi-line Strings
- Add JUnit test case
- Implement toString on class BaseType
- Require non-null name on BaseType construtor
- Prevent construction of types with null name
- Add version to maven-enforcer-plugin plugin to prevent failure of integration test JXR-143_nofork

Following this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/JXR) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[JXR-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `JXR-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

