### PR TITLE
remove unused wagon http lightweight dependency

### DIFF
--- a/maven-jxr-plugin/pom.xml
+++ b/maven-jxr-plugin/pom.xml
@@ -150,12 +150,6 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-http-lightweight</artifactId>
-      <version>3.5.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Found by the dependency analyzer. This one should be safe to remove as long as tests pass since it was only in test scope to begin with.