### PR TITLE
Fix misformatted plugin documentation

### DIFF
--- a/maven-jxr-plugin/src/main/java/org/apache/maven/plugin/jxr/AbstractJxrReport.java
+++ b/maven-jxr-plugin/src/main/java/org/apache/maven/plugin/jxr/AbstractJxrReport.java
@@ -83,14 +83,14 @@ public abstract class AbstractJxrReport extends AbstractMavenReport {
 
     /**
      * Directory where Velocity templates can be found to generate overviews, frames and summaries. Should not be used.
-     * If used, should be an absolute path, like {@code "${basedir}/myTemplates"}.
+     * If used, should be an absolute path, like <code>{@literal "${basedir}/myTemplates"}</code>.
      */
     @Parameter
     private String templateDir;
 
     /**
      * Style sheet used for the Xref HTML files. Should not be used. If used, should be an absolute path, like
-     * {@code "${basedir}/myStyles.css"}.
+     * <code>{@literal "${basedir}/myStyles.css"}</code>.
      */
     @Parameter
     private String stylesheet;


### PR DESCRIPTION
Fixes the rendering of plugin documentation that references ${placeholders} as literals, which currently is not rendering correctly on the Maven plugin site.

![image](https://github.com/apache/maven-jxr/assets/73482956/e7e29957-5bf5-4fc1-8c06-380a2e3f09df)

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

