### PR TITLE
Document behaviour around 'destDir' naming

### DIFF
--- a/maven-jxr-plugin/src/main/java/org/apache/maven/plugin/jxr/JxrReport.java
+++ b/maven-jxr-plugin/src/main/java/org/apache/maven/plugin/jxr/JxrReport.java
@@ -54,6 +54,7 @@ public class JxrReport extends AbstractJxrReport {
 
     /**
      * Directory where the Xref files will be copied to.
+     * This must end with '{@code xref}', otherwise it will be ignored.
      */
     @Parameter(defaultValue = "${project.reporting.outputDirectory}/xref")
     private String destDir;


### PR DESCRIPTION
It appears the current codebase is set up to explicitly ignore the 'destDir' parameter if it does not explicitly end with the  string 'xref'. This is currently unclear in the documentation and is only able to be discovered upon reading the source code itself.

This behaviour can be seen at https://github.com/apache/maven-jxr/blob/bbab7472bbbb8b4e0c5bd3a9b515a6cafb8e9bca/maven-jxr-plugin/src/main/java/org/apache/maven/plugin/jxr/JxrReport.java#L133-L142.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)


