### PR TITLE
Restore the document metadata dropped when the pages were ported

### DIFF
--- a/maven-jxr-plugin/src/site/markdown/examples/aggregate.md.vm
+++ b/maven-jxr-plugin/src/site/markdown/examples/aggregate.md.vm
@@ -1,3 +1,10 @@
+---
+title: Aggregating JXR Reports for Multi-module Projects
+author: 
+  - Maria Odea Ching
+date: 2010-01-20
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-jxr-plugin/src/site/markdown/examples/include-exclude.md.vm
+++ b/maven-jxr-plugin/src/site/markdown/examples/include-exclude.md.vm
@@ -1,3 +1,10 @@
+---
+title: Including/Excluding Source Files
+author: 
+  - Dennis Lundberg
+date: 2010-01-20
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-jxr-plugin/src/site/markdown/examples/linkjavadoc.md.vm
+++ b/maven-jxr-plugin/src/site/markdown/examples/linkjavadoc.md.vm
@@ -1,3 +1,10 @@
+---
+title: Linking JXR Files to Javadocs
+author: 
+  - Maria Odea Ching
+date: 2010-01-20
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-jxr-plugin/src/site/markdown/examples/nofork.md.vm
+++ b/maven-jxr-plugin/src/site/markdown/examples/nofork.md.vm
@@ -1,3 +1,10 @@
+---
+title: Generate JXR without duplicate execution of phase generate-sources.
+author: 
+  - Matt Nelson
+date: 2019-01-18
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-jxr-plugin/src/site/markdown/index.md
+++ b/maven-jxr-plugin/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Introduction
+author: 
+  - Maria Odea Ching
+date: 2010-01-20
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-jxr-plugin/src/site/markdown/usage.md.vm
+++ b/maven-jxr-plugin/src/site/markdown/usage.md.vm
@@ -1,3 +1,12 @@
+---
+title: Usage
+author: 
+  - Fabrice Bellingard
+  - bellingard.NO-SPAM@gmail.com
+  - Maria Odea Ching
+date: 2010-04-27
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/java.md
+++ b/src/site/markdown/examples/java.md
@@ -1,3 +1,10 @@
+---
+title: Using Maven JXR in Java
+author: 
+  - Vincent Siveton
+date: 2010-01-20
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,3 +1,11 @@
+---
+title: Introduction
+author: 
+  - Jason van Zyl
+  - Vincent Siveton
+date: 2010-01-20
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The site pages lost their document metadata when they were ported from APT.

An APT document opens with a header block giving its title, authors and date, and
`doxia-converter` turns that into YAML front matter. The port dropped the front matter
along with the converter's per-line licence comments, so the generated pages lost their
`<meta name="author">` and date, and took their `<title>` from the first heading instead
of from the document title.

Building one project's site from the APT sources and from the ported Markdown shows the
difference:

| | `<title>` produced |
|---|---|
| APT original | `Release Notes - Modello` |
| ported Markdown | `Modello - Modello` |
| with this change | `Release Notes - Modello` |

The front matter has to come first in the file, because the Markdown parser only looks
for it when the source begins with `---`; a licence header ahead of it would hide it.
RAT is happy either way.

Verified by building the site before and after and comparing `<title>` and the author
meta tags of every generated page, and by confirming the front matter does not reach
the rendered body.