### PR TITLE
Drop branch protection for the retired jxr-3.4.x line

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -30,7 +30,6 @@ github:
     rebase: true
   protected_branches:
     master: { }
-    jxr-3.4.x: {}
   pull_requests:
     del_branch_on_merge: true
   features:


### PR DESCRIPTION
`jxr-3.4.x` was the Doxia 1.x maintenance line. With the Doxia 2.0.0 stack completed there is
nothing left to release from it, and `git` puts every commit on it in `master` already
(`compare/master...jxr-3.4.x` → `ahead_by: 0`), so the branch carries no history of its own.
`jxr-3.4.0` remains tagged.

Removing the protection entry is the prerequisite for deleting the branch; I will delete it once
this lands. Nothing else in the file changes.

This change was created with AI assistance.
