### PR TITLE
Replace Wagon's Repository with java.net.URI

### DIFF
--- a/maven-jxr-plugin/pom.xml
+++ b/maven-jxr-plugin/pom.xml
@@ -41,7 +41,6 @@ under the License.
     <mavenVersion>3.9.12</mavenVersion>
     <!-- like Maven -->
     <resolverVersion>1.9.27</resolverVersion>
-    <wagonVersion>3.5.3</wagonVersion>
   </properties>
 
   <dependencies>
@@ -81,11 +80,6 @@ under the License.
       <artifactId>maven-model</artifactId>
       <version>${mavenVersion}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-provider-api</artifactId>
-      <version>${wagonVersion}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>

--- a/maven-jxr-plugin/src/main/java/org/apache/maven/plugin/jxr/JxrReportUtil.java
+++ b/maven-jxr-plugin/src/main/java/org/apache/maven/plugin/jxr/JxrReportUtil.java
@@ -19,6 +19,8 @@
 package org.apache.maven.plugin.jxr;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,7 +29,6 @@ import org.apache.maven.model.PluginExecution;
 import org.apache.maven.model.ReportPlugin;
 import org.apache.maven.model.Site;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.wagon.repository.Repository;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
@@ -218,15 +219,43 @@ public class JxrReportUtil {
             return null;
         }
 
-        Repository repository = new Repository(site.getId(), site.getUrl());
-        if (StringUtils.isEmpty(repository.getBasedir())) {
-            return repository.getHost();
+        return siteStructure(site.getUrl());
+    }
+
+    /**
+     * Turns a distributionManagement site URL into the host followed by its path.
+     * <p>
+     * A site URL is not always a plain hierarchical URI: the ASF convention wraps it in an SCM prefix
+     * ({@code scm:svn:https://...}), and a WebDAV target is conventionally written {@code dav:https://...}. Such a
+     * prefix leaves an opaque URI, so peel one off at a time until a URI that carries a path is left.
+     *
+     * @param siteUrl the {@code <distributionManagement><site><url>} value, not null nor empty
+     * @return the structure relative path
+     * @throws IOException if the URL cannot be parsed
+     */
+    private static String siteStructure(String siteUrl) throws IOException {
+        URI uri;
+        String remaining = siteUrl;
+        while (true) {
+            try {
+                uri = new URI(remaining);
+            } catch (URISyntaxException e) {
+                throw new IOException("The URL in the site is not a valid URI: '" + siteUrl + "'.", e);
+            }
+            if (!uri.isOpaque()) {
+                break;
+            }
+            remaining = uri.getSchemeSpecificPart();
         }
 
-        if (repository.getBasedir().startsWith("/")) {
-            return repository.getHost() + repository.getBasedir();
+        // a file: URL carries no authority; Wagon reported those as localhost and the staging paths depend on it
+        String host = uri.getHost() == null ? "localhost" : uri.getHost();
+
+        String path = uri.getPath();
+        if (path == null || path.isEmpty()) {
+            path = "/";
         }
 
-        return repository.getHost() + '/' + repository.getBasedir();
+        return path.startsWith("/") ? host + path : host + '/' + path;
     }
 }

--- a/maven-jxr-plugin/src/test/java/org/apache/maven/plugin/jxr/JxrReportUtilTest.java
+++ b/maven-jxr-plugin/src/test/java/org/apache/maven/plugin/jxr/JxrReportUtilTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.jxr;
+
+import java.io.IOException;
+
+import org.apache.maven.model.DistributionManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Site;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test {@link JxrReportUtil}.
+ */
+class JxrReportUtilTest {
+
+    /**
+     * The expectations are the values Wagon's {@code Repository} produced for the same URLs, with the exception of
+     * the {@code dav:} one, see {@link #davUrlKeepsItsHost()}.
+     */
+    @Test
+    void structureFollowsTheSiteUrl() throws IOException {
+        assertStructure(
+                "maven.apache.org/plugins/maven-jxr-plugin/", "https://maven.apache.org/plugins/maven-jxr-plugin/");
+        assertStructure(
+                "maven.apache.org/plugins/maven-jxr-plugin", "https://maven.apache.org/plugins/maven-jxr-plugin");
+        assertStructure("maven.apache.org/", "https://maven.apache.org");
+        assertStructure("maven.apache.org/plugins/x", "https://maven.apache.org:8080/plugins/x");
+        assertStructure(
+                "svn.apache.org/repos/asf/maven/website/components/x",
+                "scm:svn:https://svn.apache.org/repos/asf/maven/website/components/x");
+        assertStructure(
+                "people.apache.org/www/maven.apache.org/plugins/x",
+                "scp://user@people.apache.org/www/maven.apache.org/plugins/x");
+        assertStructure("localhost/tmp/site", "file:///tmp/site");
+    }
+
+    /**
+     * Wagon parsed {@code dav:https://maven.apache.org/plugins/x} into host {@code https} and base directory
+     * {@code .apache.org/plugins/x}. The {@code dav:} prefix is now peeled off like the SCM one.
+     */
+    @Test
+    void davUrlKeepsItsHost() throws IOException {
+        assertEquals(
+                "maven.apache.org/plugins/x",
+                JxrReportUtil.getStructure(projectWithSiteUrl("dav:https://maven.apache.org/plugins/x"), false));
+    }
+
+    @Test
+    void unparseableUrlIsReported() {
+        assertThrows(
+                IOException.class,
+                () -> JxrReportUtil.getStructure(projectWithSiteUrl("https://maven.apache.org/a b"), false));
+    }
+
+    @Test
+    void missingSiteUrlIsIgnoredWhenAsked() throws IOException {
+        assertNull(JxrReportUtil.getStructure(projectWithSiteUrl(""), true));
+    }
+
+    @Test
+    void missingSiteUrlIsReportedOtherwise() {
+        assertThrows(IOException.class, () -> JxrReportUtil.getStructure(projectWithSiteUrl(""), false));
+    }
+
+    /**
+     * Without distributionManagement the structure falls back to the project name hierarchy.
+     */
+    @Test
+    void structureFallsBackToTheProjectHierarchy() throws IOException {
+        Model model = new Model();
+        model.setName("Child");
+        MavenProject project = new MavenProject(model);
+
+        Model parentModel = new Model();
+        parentModel.setName("Parent");
+        project.setParent(new MavenProject(parentModel));
+
+        assertEquals("Parent/Child", JxrReportUtil.getStructure(project, false));
+    }
+
+    private static void assertStructure(String expected, String siteUrl) throws IOException {
+        assertEquals(expected, JxrReportUtil.getStructure(projectWithSiteUrl(siteUrl), false), siteUrl);
+    }
+
+    private static MavenProject projectWithSiteUrl(String siteUrl) {
+        Site site = new Site();
+        site.setId("site");
+        site.setUrl(siteUrl);
+
+        DistributionManagement distributionManagement = new DistributionManagement();
+        distributionManagement.setSite(site);
+
+        Model model = new Model();
+        model.setDistributionManagement(distributionManagement);
+
+        return new MavenProject(model);
+    }
+}


### PR DESCRIPTION
The plugin's only use of Wagon was `getStructure`, which built an `org.apache.maven.wagon.repository.Repository` to split a distributionManagement site URL into host plus path — the staging directory `site:stage` writes into. `java.net.URI` does that, once the SCM prefix is peeled off.

Two behaviour notes:

- A `dav:` URL now keeps its real host. Wagon parsed `dav:https://maven.apache.org/plugins/x` into host `https` and base directory `.apache.org/plugins/x`, so the staged path was nonsense. The `dav:` prefix is now peeled off the way `scm:svn:` always was.
- A site URL that is not a URI at all is now reported rather than silently yielding a garbage path.

There were no tests on this method. The new ones pin the values Wagon produced for every URL form it handled — `https` with and without a trailing slash, no path, an explicit port, `scm:svn:`, `scp://user@host`, `file:` — so the replacement is checked against the old parser rather than against my reading of it.

*This change was created with AI assistance.*