### PR TITLE
Implement getOutputPath() and deprecate getOutputName()

### DIFF
--- a/maven-jxr-plugin/src/main/java/org/apache/maven/plugin/jxr/JxrReport.java
+++ b/maven-jxr-plugin/src/main/java/org/apache/maven/plugin/jxr/JxrReport.java
@@ -116,8 +116,20 @@ public class JxrReport extends AbstractJxrReport {
         return getBundle(locale).getString("report.xref.main.name");
     }
 
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
     @Override
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOutputPath() {
         return "xref/index";
     }
 

--- a/maven-jxr-plugin/src/main/java/org/apache/maven/plugin/jxr/JxrTestReport.java
+++ b/maven-jxr-plugin/src/main/java/org/apache/maven/plugin/jxr/JxrTestReport.java
@@ -98,8 +98,20 @@ public class JxrTestReport extends AbstractJxrReport {
         return getBundle(locale).getString("report.xref.test.name");
     }
 
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
     @Override
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOutputPath() {
         return "xref-test/index";
     }
 


### PR DESCRIPTION
Adopts the report output method that Maven Reporting API 4.0.0 introduced, following the pattern in the [report plugin guide](https://maven.apache.org/guides/plugin/guide-java-report-plugin-development.html) and already used by maven-javadoc-plugin and maven-pmd-plugin: `getOutputPath()` carries the value, and `getOutputName()` stays as a deprecated delegate because the API still declares it abstract.

No behaviour change — the rendered report paths are the same strings.

*This change was created with AI assistance.*
